### PR TITLE
feat: 로고 크기 수정

### DIFF
--- a/src/components/common/header/HeaderStyle.tsx
+++ b/src/components/common/header/HeaderStyle.tsx
@@ -44,7 +44,8 @@ export const HeaderRight = styled.div`
 `;
 
 export const Logo = styled.img`
-  width: 30%;
+  width: 22%;
+  min-width: 100px;
   cursor: pointer;
 `;
 
@@ -75,7 +76,7 @@ export const MenuItem = styled.div`
   align-items: center;
   justify-content: center;
 
-  font-size: clamp(13px, 1vw, 16px);
+  font-size: clamp(12px, 1vw, 16px);
   font-weight: 500;
   line-height: 130%;
   letter-spacing: -0.4px;


### PR DESCRIPTION
로고 크기가 피그마 디자인보다 크게 나와서 좀 더 작게 수정했습니다.
그리고 너비가 줄어들때 너무 작아지면 잘 안보여서 로고에도 min-width를 100px 줬습니다
